### PR TITLE
add live testing framework

### DIFF
--- a/.github/workflows/live-testing.yaml
+++ b/.github/workflows/live-testing.yaml
@@ -1,0 +1,20 @@
+name: Live tests of Text Mining Provider KPs
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # runs at midnight every day
+
+jobs:
+
+  live-tests:
+    runs-on: ubuntu-latest
+    name: Run tests on live text mining provider KPs
+    env:
+      IMAGE_NAME: kg-live-test
+      DOCKERFILE: testing/live/Dockerfile
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build Docker Image
+        run: docker build --tag "$IMAGE_NAME:latest" -f "$DOCKERFILE" testing/live
+      - name: Run the Docker container to run the live tests
+        run: docker run --rm "$IMAGE_NAME:latest"

--- a/testing/live/Dockerfile
+++ b/testing/live/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:latest
+
+RUN apt-get update && apt-get install -y \
+    jq \
+    wget \
+    curl
+
+WORKDIR /home/dev
+# install bash_unit
+RUN wget -O - https://raw.githubusercontent.com/pgrange/bash_unit/master/install.sh | bash
+
+COPY entrypoint.sh /home/dev/
+RUN chmod 755 /home/dev/entrypoint.sh
+
+COPY tests /home/dev/tests/
+
+ENV TEXT_MINED_TRAPI_URL https://api.bte.ncats.io/v1/smartapi/978fe380a147a8641caf72320862697b/query/
+ENV COOCCUR_TRAPI_URL https://api.bte.ncats.io/v1/smartapi/5be0f321a829792e934545998b9c6afe/query/
+
+ENTRYPOINT [ "/home/dev/entrypoint.sh" ]
+
+

--- a/testing/live/entrypoint.sh
+++ b/testing/live/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/home/dev/bash_unit /home/dev/tests/test*

--- a/testing/live/tests/q1.json
+++ b/testing/live/tests/q1.json
@@ -1,0 +1,21 @@
+{
+    "message": {
+        "query_graph": {
+            "nodes": {
+                "n0": {
+                    "id": "CHEBI:3215"
+                },
+                "n1": {
+                    "category": "biolink:GeneOrGeneProduct"
+                }
+            },
+            "edges": {
+                "e00": {
+                    "subject": "n0",
+                    "object": "n1",
+                    "predicate": "biolink:entity_negatively_regulates_entity"
+                }
+            }
+        }
+    }
+}

--- a/testing/live/tests/q2.json
+++ b/testing/live/tests/q2.json
@@ -1,0 +1,20 @@
+{
+    "message": {
+        "query_graph": {
+            "nodes": {
+                "n0": {
+                  "id": "CHEBI:6801"
+                },
+                "n3": {
+                    "id": "HP:0003074"
+                }
+            },
+            "edges": {
+                "e03": {
+                    "subject": "n0",
+                    "object": "n3"
+                }
+            }
+        }
+    }
+}

--- a/testing/live/tests/test_cooccur-kg
+++ b/testing/live/tests/test_cooccur-kg
@@ -1,0 +1,35 @@
+
+Q2=$(cat /home/dev/tests/q2.json)
+
+test_should_return_single_relation_when_both_subj_obj_specified() {
+
+    # query the TRAPI endpoint
+    curl --location --request POST "$COOCCUR_TRAPI_URL" \
+         --header 'Content-Type: application/json' \
+         --data-raw "${Q2}" > a2.json
+
+    # extract the node identifiers from the returned knowledge graph
+    jq '.message.knowledge_graph.edges 
+        | to_entries 
+        | map(.key)' a2.json > a2.edge.keys 
+
+    msg1="=================================================================\n
+          The expected edge is not present in the knowledge graph.\n
+          ================================================================="
+
+    expected_edge="CHEBI:6801-biolink:related_to-HP:0003074"
+    assert "grep $expected_edge a2.edge.keys" "$msg1"
+
+    msg2="=================================================================\n
+         Both the subject and object query node are constrained to specific\n
+         CURIEs, therefore only a single edge should be returned.\n
+         However, it appears that more than one edge is returned for some reason.\n
+         ================================================================="
+
+    # There should be 3 lines: open/closing brackets and the expected edge
+    edge_count=$(wc -l a2.edge.keys)
+    assert_equals "3 a2.edge.keys" "$edge_count" "$msg2"
+           
+    # clean up
+    rm a2.json a2.edge.keys
+}

--- a/testing/live/tests/test_text-mined-assertion-kg
+++ b/testing/live/tests/test_text-mined-assertion-kg
@@ -1,0 +1,28 @@
+
+Q1=$(cat /home/dev/tests/q1.json)
+
+test_should_return_curie_that_is_used_in_query() {
+
+    # query the TRAPI endpoint
+    curl --location --request POST "$TEXT_MINED_TRAPI_URL" \
+         --header 'Content-Type: application/json' \
+         --data-raw "${Q1}" > a1.json
+
+    # extract the node identifiers from the returned knowledge graph
+    jq '.message.knowledge_graph.nodes 
+        | to_entries 
+        | map(select(.key | match("CHEBI:77431";"i"))) 
+        | map(.key)' a1.json > a1.node.keys 
+
+    msg="=================================================================\n
+         Check that the CURIE specified in the query is returned as a node\n
+         in the knowledge graph. For this particular query we noticed that\n
+         CHEBI:3215 is not returned. Instead, CHEBI:77431 is used as BTE\n
+         has merged the two CHEBI concepts.\n
+         ================================================================="
+
+    assert "grep CHEBI:3215 a1.node.keys" "$msg"
+           
+    # clean up
+    rm a1.json a1.node.keys
+}


### PR DESCRIPTION
Add framework to test the live KGs. Note that the tests are currently failing due to some issues that need to be addressed. The tests are set to run every night at midnight via GitHub Actions.